### PR TITLE
Fix build on opensuse

### DIFF
--- a/Normaliz-offline/install_normaliz.sh
+++ b/Normaliz-offline/install_normaliz.sh
@@ -21,7 +21,7 @@ fi
 source $(dirname "$0")/install_scripts_opt/common.sh
 
 
-CONFIGURE_FLAGS="--prefix=${PREFIX}"
+CONFIGURE_FLAGS="--prefix=${PREFIX} --libdir=${PREFIX}/lib"
 if [ "$GMP_INSTALLDIR" != "" ]; then
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-gmp=$GMP_INSTALLDIR"
 fi

--- a/Normaliz-offline/install_scripts_opt/install_nmz_flint.sh
+++ b/Normaliz-offline/install_scripts_opt/install_nmz_flint.sh
@@ -8,7 +8,7 @@ source $(dirname "$0")/common.sh
 
 # NK: Need PIC for libflint
 
-CONFIGURE_FLAGS="--prefix=${PREFIX} --enable-shared=yes --enable-static=yes --with-pic=yes"
+CONFIGURE_FLAGS="--prefix=${PREFIX} --libdir=${PREFIX}/lib --enable-shared=yes --enable-static=yes --with-pic=yes"
 
 # if [ "$OSTYPE" != "msys" ]; then
 # 	CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-mpfr=${PREFIX}"

--- a/Normaliz-offline/install_scripts_opt/install_nmz_mpfr.sh
+++ b/Normaliz-offline/install_scripts_opt/install_nmz_mpfr.sh
@@ -7,7 +7,7 @@ echo "::group::mpfr"
 source $(dirname "$0")/common.sh
 
 # NK: Make PIC
-CONFIGURE_FLAGS="--prefix=${PREFIX} --enable-shared=yes --with-pic=yes"
+CONFIGURE_FLAGS="--prefix=${PREFIX} --libdir=${PREFIX}/lib --enable-shared=yes --with-pic=yes"
 
 if [ "$OSTYPE" != "msys" ]; then
 	CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-mpfr=${PREFIX}"

--- a/dune
+++ b/dune
@@ -11,13 +11,7 @@
 
 (rule
   (target link_flags.sexp)
-  (action (write-file link_flags.sexp "(-std=c++14)"))
-  (enabled_if (= %{ocaml-config:system} macosx)))
-
-(rule
-  (target link_flags.sexp)
-  (action (write-file link_flags.sexp "()"))
-  (enabled_if (<> %{ocaml-config:system} macosx)))
+  (action (write-file link_flags.sexp "(-std=c++14)")))
 
 (foreign_library
  (archive_name normaliz_stubs)
@@ -66,7 +60,8 @@
  (flags (:standard -w -32))
  (name test)
  (modules test)
- (libraries normalizffi ounit2))
+ (libraries normalizffi ounit2)
+ (link_flags -cclib -leanticxx))
 
 (rule
  (deps (source_tree Normaliz-offline))

--- a/dune
+++ b/dune
@@ -27,7 +27,7 @@
 
 (rule
   (target lib_flags.sexp)
-  (action (write-file lib_flags.sexp "(-L. -lstdc++ -lgmpxx -lgmp -lgomp -lnormaliz -lflint)"))
+  (action (write-file lib_flags.sexp "(-L. -lstdc++ -lgmpxx -lgmp -lgomp -lnormaliz -lflint -leanticxx)"))
   (enabled_if (<> %{ocaml-config:system} macosx)))
 
 (library
@@ -60,8 +60,7 @@
  (flags (:standard -w -32))
  (name test)
  (modules test)
- (libraries normalizffi ounit2)
- (link_flags -cclib -leanticxx))
+ (libraries normalizffi ounit2))
 
 (rule
  (deps (source_tree Normaliz-offline))


### PR DESCRIPTION
I had a few issues installing this package on my linux distribution of choice (OpenSUSE Tumbleweed), which these changes should fix. 

Firstly, the library files were being put in Normaliz-offline/local/lib64 instead of Normaliz-offline/local/lib, which is hard-coded in a few places. Secondly, my version of e-antic (2.1.1) requires c++14. Lastly, I needed to manually add -leanticxx (I'm not exactly sure why it's an issue on my system and not others).